### PR TITLE
handle ZMQError, which happens if no connections are set up

### DIFF
--- a/chatimusmaximus/__main__.py
+++ b/chatimusmaximus/__main__.py
@@ -7,6 +7,8 @@ from PyQt5 import QtWidgets
 from quamash import QEventLoop
 import pluginmanager
 
+from zmq.error import ZMQError
+
 from chatimusmaximus.gui import MainWindow
 from chatimusmaximus.messaging import ZmqMessaging
 from chatimusmaximus.util import create_services_from_settings
@@ -48,10 +50,13 @@ def main():
 
     atexit.register(_destroy_services, services)
 
-    messager.subscribe_to_publishers(settings_data['sockets_to_connect_to'])
-    cmd_line_address = settings_data['display']['address']
-    if cmd_line_address:
-        messager.publish_to_address(cmd_line_address)
+    try:
+        messager.subscribe_to_publishers(settings_data['sockets_to_connect_to'])
+        cmd_line_address = settings_data['display']['address']
+        if cmd_line_address:
+            messager.publish_to_address(cmd_line_address)
+    except ZMQError:
+        pass
 
     # show me the money!
     main_window.show()


### PR DESCRIPTION
I wanted to check out the app without setting up all the connections.
Prior to this fix, the following error occured:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "chatimusmaximus/__main__.py", line 81, in <module>
    main()
  File "chatimusmaximus/__main__.py", line 51, in main
    messager.subscribe_to_publishers(settings_data['sockets_to_connect_to'])
  File "/Users/julieengel/tmp/CHATIMUSMAXIMUS/chatimusmaximus/messaging.py", line 22, in subscribe_to_publishers
    self.sub_socket.connect(address)
  File "zmq/backend/cython/socket.pyx", line 514, in zmq.backend.cython.socket.Socket.connect (zmq/backend/cython/socket.c:5376)
zmq.error.ZMQError: Invalid argument
```

After this fix is applied, the GUI will show/open normally, of course without any connections active.
